### PR TITLE
Update 15-workflow-sets.Rmd to use `option_add(param_info = ...)`

### DIFF
--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -194,7 +194,7 @@ The `option` column is a placeholder for any arguments to use when we evaluate t
 ```{r workflow-sets-info-update}
 normalized <- 
    normalized %>% 
-   option_add(param = nnet_param, id = "normalized_neural_network")
+   option_add(param_info = nnet_param, id = "normalized_neural_network")
 normalized
 ```
 


### PR DESCRIPTION
This is in reference to [tidymodels/workflows#49](https://github.com/tidymodels/workflowsets/issues/49#issuecomment-847127601) where the parameter object must be specified as `param_info` when passing it via `option_add` to a `workflow_set`. `param` is a partial that will likely work for passing the argument to `param_info` appropriately, but I incorrectly assumed that it might also be named `parameters`. This might prevent that confusion for others.